### PR TITLE
fix(fleetmanager): persist instance state before invoking ready callback

### DIFF
--- a/pkg/fleetmanager/event_manager.go
+++ b/pkg/fleetmanager/event_manager.go
@@ -176,6 +176,7 @@ func (eem *EdgegapEventManager) handleInstanceEvent(ctx context.Context, logger 
 	}
 
 	stopping := false
+	readyCallbackId := ""
 
 	switch strings.ToUpper(instanceEvent.Action) {
 	case InstanceEventStateReady:
@@ -189,7 +190,7 @@ func (eem *EdgegapEventManager) handleInstanceEvent(ctx context.Context, logger 
 		if err != nil {
 			return "", err
 		}
-		fmInstance.callbackHandler.InvokeCallback(ei.CallbackId, runtime.CreateSuccess, instance, nil, nil, nil)
+		readyCallbackId = ei.CallbackId
 
 	case InstanceEventStateStop:
 		logger.Info("Edgegap instance stop #%s: %s", instanceEvent.InstanceId, instanceEvent.Message)
@@ -208,6 +209,14 @@ func (eem *EdgegapEventManager) handleInstanceEvent(ctx context.Context, logger 
 	err = eem.sm.updateDbInstance(ctx, instance)
 	if err != nil {
 		return "", err
+	}
+
+	// Invoke the ready callback only after the updated instance (including the
+	// merged game_server metadata) is persisted. Otherwise clients notified by
+	// the callback may query instance_list and read a stale record that is
+	// still missing the game_server fields, causing empty connection info.
+	if readyCallbackId != "" {
+		fmInstance.callbackHandler.InvokeCallback(readyCallbackId, runtime.CreateSuccess, instance, nil, nil, nil)
 	}
 
 	if stopping {


### PR DESCRIPTION
Problem
                                                                                                                                                                                                                                        In `handleInstanceEvent`, the `InstanceEventStateReady` branch calls `InvokeCallback` before `updateDbInstance` runs. The callback typically notifies clients that the server is ready, and those clients react by querying the
  instance through `instance_list`. Because the storage update has not happened yet, that query can read a stale record missing the `game_server` fields merged from the instance event, and returns empty connection info.                                                                                                                                                                                                                                                   In our project this shows up as an empty `game_server` on the first few `instance_list` attempts right after a client receives the `connection-info` notification. Client-side retries usually recover once the storage write lands,   but occasionally all retries fall inside the race window and the player is dropped back to the menu.                                                                                                                               
  ### Fix

  Move `InvokeCallback` out of the switch and run it after `updateDbInstance` succeeds, for the Ready branch only. `Stop`, `Error` and `default` paths are unchanged. If the storage update fails the callback is not invoked, which
  also prevents notifying clients that the server is ready when persistence failed.

  ### Testing

  No tests were added; the package has none. Verified locally with `go build ./pkg/...` and `go vet ./pkg/...`.
