### PR TITLE
feat(deploymentV2) Upgrade to Edgegap deployment V2 from beta

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,7 @@ local.yml
 
 # Claude AI configuration
 .claude/
+
+
+# Local folder
+.local/

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/edgegap/nakama-edgegap
 
-go 1.25.5
+go 1.26.1
 
-require github.com/heroiclabs/nakama-common v1.44.2
+require github.com/heroiclabs/nakama-common v1.45.0
 
 require google.golang.org/protobuf v1.36.11 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,5 +2,7 @@ github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/heroiclabs/nakama-common v1.44.2 h1:aynrv/lFSI/1N54JxQ81FD80Iw7OL1yLrySwUemOOBU=
 github.com/heroiclabs/nakama-common v1.44.2/go.mod h1:/KLxEy4+JdasHJLPt+tAXJJ8eXywWr/J+Q+KY+/vg7E=
+github.com/heroiclabs/nakama-common v1.45.0 h1:cjmQH7hf+vdgDZtB8+3d0NsNoANwbluG29hKe1epFWI=
+github.com/heroiclabs/nakama-common v1.45.0/go.mod h1:Kn0vqduhT5U1JkKVp1bu8tn3LYFX8im5jTDrIlwcnEU=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=

--- a/pkg/fleetmanager/authentication.go
+++ b/pkg/fleetmanager/authentication.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+
 	"github.com/heroiclabs/nakama-common/api"
 	"github.com/heroiclabs/nakama-common/runtime"
 )

--- a/pkg/fleetmanager/client_rpc.go
+++ b/pkg/fleetmanager/client_rpc.go
@@ -92,7 +92,9 @@ func createInstanceSession(ctx context.Context, logger runtime.Logger, db *sql.D
 			}
 			return
 		case runtime.CreateTimeout:
-			logger.WithField("error", createErr.Error()).Error("Failed to create Edgegap instance, timed out")
+			// createErr may be nil even though the framework reports a timeout —
+			// pass the interface value directly so we don't .Error() a nil.
+			logger.WithField("error", createErr).Error("Failed to create Edgegap instance, timed out")
 
 			// Send notification to client that instance session creation timed out
 			for _, userId := range req.UserIds {
@@ -105,7 +107,7 @@ func createInstanceSession(ctx context.Context, logger runtime.Logger, db *sql.D
 				}
 			}
 		default:
-			logger.WithField("error", createErr.Error()).Error("Failed to create Edgegap instance")
+			logger.WithField("error", createErr).Error("Failed to create Edgegap instance")
 
 			// Send notification to client that instance session couldn't be created
 			for _, userId := range req.UserIds {

--- a/pkg/fleetmanager/dynamic_version_manager.go
+++ b/pkg/fleetmanager/dynamic_version_manager.go
@@ -6,30 +6,31 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	
+
+	"net/http"
+
 	"github.com/edgegap/nakama-edgegap/internal/helpers"
 	"github.com/heroiclabs/nakama-common/runtime"
-	"net/http"
 )
 
 const (
 	RpcIdUpdateEdgegapVersion = "update_edgegap_version"
 	RpcIdGetEdgegapVersion    = "get_edgegap_version"
-	
+
 	// Error messages
-	ErrorMessageUnauthorized = "unauthorized: this RPC requires server authentication"
+	ErrorMessageUnauthorized        = "unauthorized: this RPC requires server authentication"
 	ErrorMessageNoVersionConfigured = "No Edgegap version configured"
-	ErrorMessageSetVersionRPC = "Please set version using update_edgegap_version RPC"
-	
+	ErrorMessageSetVersionRPC       = "Please set version using update_edgegap_version RPC"
+
 	// Log messages
 	LogMessageStoringInitialVersion = "No version found in storage, storing initial version: %s"
-	LogMessageFailedStoreInitial = "Failed to store initial version during startup: %v"
-	LogMessageFailedCheckVersion = "Failed to check for existing version during startup: %v"
-	LogMessageVersionUpdated = "Edgegap version updated to: %s"
-	LogMessageClientAttemptedS2S = "Client attempted to call server-to-server RPC"
-	
+	LogMessageFailedStoreInitial    = "Failed to store initial version during startup: %v"
+	LogMessageFailedCheckVersion    = "Failed to check for existing version during startup: %v"
+	LogMessageVersionUpdated        = "Edgegap version updated to: %s"
+	LogMessageClientAttemptedS2S    = "Client attempted to call server-to-server RPC"
+
 	// Response fields
-	ResponseFieldSource = "source"
+	ResponseFieldSource   = "source"
 	ResponseSourceDynamic = "dynamic"
 )
 
@@ -51,7 +52,7 @@ func NewDynamicVersionManager(config *EdgegapManagerConfiguration, sm *StorageMa
 		sm:     sm,
 		logger: logger,
 	}
-	
+
 	// Check if initial version should be stored at startup
 	if config.InitialVersion != "" {
 		ctx := context.Background()
@@ -69,7 +70,7 @@ func NewDynamicVersionManager(config *EdgegapManagerConfiguration, sm *StorageMa
 			}
 		}
 	}
-	
+
 	return dvm
 }
 
@@ -80,14 +81,14 @@ func (dvm *DynamicVersionManager) ValidateVersionWithEdgegap(version string) err
 	if err != nil {
 		return fmt.Errorf("failed to validate version with Edgegap API: %w", err)
 	}
-	
+
 	if reply.StatusCode != http.StatusOK {
 		if reply.StatusCode == http.StatusNotFound {
 			return runtime.NewError(fmt.Sprintf("version '%s' does not exist for application '%s'", version, dvm.config.Application), 5) // NOT_FOUND
 		}
 		return runtime.NewError(fmt.Sprintf("failed to validate version with Edgegap API, status: %s", reply.Status), 13) // INTERNAL
 	}
-	
+
 	return nil
 }
 
@@ -116,7 +117,6 @@ func (dvm *DynamicVersionManager) UpdateEdgegapVersion(ctx context.Context, logg
 	if request.Version == "" {
 		return "", runtime.NewError("version cannot be empty", 3) // INVALID_ARGUMENT
 	}
-
 
 	// Validate the version exists in Edgegap before storing
 	if err := dvm.ValidateVersionWithEdgegap(request.Version); err != nil {

--- a/pkg/fleetmanager/edgegap_manager.go
+++ b/pkg/fleetmanager/edgegap_manager.go
@@ -58,13 +58,15 @@ func NewEdgegapManager(ctx context.Context, logger runtime.Logger, initializer r
 
 	// Register RPC functions for handling various events
 	rpcToRegisters := map[string]func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, payload string) (string, error){
-		RpcIdEventDeployment:       eem.handleDeploymentEvent,
-		RpcIdEventConnection:       eem.handleConnectionEvent,
-		RpcIdEventInstance:         eem.handleInstanceEvent,
-		RpcIdInstanceSessionCreate: createInstanceSession,
-		RpcIdInstanceSessionGet:    getInstanceSession,
-		RpcIdInstanceSessionJoin:   joinInstanceSession,
-		RpcIdInstanceSessionList:   listInstanceSession,
+		RpcIdEventDeploymentReady:      eem.handleDeploymentReadyEvent,
+		RpcIdEventDeploymentError:      eem.handleDeploymentErrorEvent,
+		RpcIdEventDeploymentTerminated: eem.handleDeploymentTerminatedEvent,
+		RpcIdEventConnection:           eem.handleConnectionEvent,
+		RpcIdEventInstance:             eem.handleInstanceEvent,
+		RpcIdInstanceSessionCreate:     createInstanceSession,
+		RpcIdInstanceSessionGet:        getInstanceSession,
+		RpcIdInstanceSessionJoin:       joinInstanceSession,
+		RpcIdInstanceSessionList:       listInstanceSession,
 		// S2S RPCs for managing Edgegap version
 		RpcIdUpdateEdgegapVersion: dvm.UpdateEdgegapVersion,
 		RpcIdGetEdgegapVersion:    dvm.GetEdgegapVersion,
@@ -93,7 +95,7 @@ func (em *EdgegapManager) getFormattedUrl(path string) string {
 }
 
 // CreateDeployment initiates a new deployment on Edgegap using the given users' IP addresses and metadata.
-func (em *EdgegapManager) CreateDeployment(usersIP []string, metadata map[string]any) (*EdgegapBetaDeployment, error) {
+func (em *EdgegapManager) CreateDeployment(usersIP []string, metadata map[string]any) (*EdgegapDeploymentResponse, error) {
 	// Prepare deployment data
 	deployment, err := em.getDeploymentCreation(usersIP, metadata)
 	if err != nil {
@@ -101,7 +103,7 @@ func (em *EdgegapManager) CreateDeployment(usersIP []string, metadata map[string
 	}
 
 	// Send deployment request to Edgegap API
-	reply, err := em.apiHelper.Post("/beta/deployments", deployment)
+	reply, err := em.apiHelper.Post("/v2/deployments", deployment)
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +115,7 @@ func (em *EdgegapManager) CreateDeployment(usersIP []string, metadata map[string
 		if err != nil {
 			return nil, err
 		}
-		var msg EdgegapBetaDeployment
+		var msg EdgegapDeploymentResponse
 		err = json.Unmarshal(body, &msg)
 		if err != nil {
 			return nil, err
@@ -127,7 +129,7 @@ func (em *EdgegapManager) CreateDeployment(usersIP []string, metadata map[string
 		return nil, err
 	}
 
-	var response EdgegapBetaDeployment
+	var response EdgegapDeploymentResponse
 	err = json.Unmarshal(body, &response)
 
 	return &response, err
@@ -140,7 +142,8 @@ func (em *EdgegapManager) getDeploymentCreation(usersIP []string, metadata map[s
 	// Convert user IPs into EdgegapDeploymentUser objects
 	for _, ip := range usersIP {
 		users = append(users, EdgegapDeploymentUser{
-			IpAddress: ip,
+			UserType: "ip_address",
+			UserData: EdgegapUserData{IpAddress: ip},
 		})
 	}
 
@@ -165,9 +168,9 @@ func (em *EdgegapManager) getDeploymentCreation(usersIP []string, metadata map[s
 
 	// Construct deployment request payload
 	return &EdgegapDeploymentCreation{
-		ApplicationName: em.configuration.Application,
-		Version:         version,
-		Users:           users,
+		Application: em.configuration.Application,
+		Version:     version,
+		Users:       users,
 		EnvironmentVariables: []EdgegapEnvironmentVariable{
 			{
 				Key:      "NAKAMA_CONNECTION_EVENT_URL",
@@ -188,9 +191,9 @@ func (em *EdgegapManager) getDeploymentCreation(usersIP []string, metadata map[s
 		Tags: []string{
 			"nakama",
 		},
-		Webhook: EdgegapWebhook{
-			Url: em.getFormattedUrl(RpcIdEventDeployment),
-		},
+		WebhookOnReady:      EdgegapWebhook{Url: em.getFormattedUrl(RpcIdEventDeploymentReady)},
+		WebhookOnError:      EdgegapWebhook{Url: em.getFormattedUrl(RpcIdEventDeploymentError)},
+		WebhookOnTerminated: EdgegapWebhook{Url: em.getFormattedUrl(RpcIdEventDeploymentTerminated)},
 	}, nil
 }
 

--- a/pkg/fleetmanager/edgegap_manager.go
+++ b/pkg/fleetmanager/edgegap_manager.go
@@ -115,12 +115,11 @@ func (em *EdgegapManager) CreateDeployment(usersIP []string, metadata map[string
 		if err != nil {
 			return nil, err
 		}
-		var msg EdgegapDeploymentResponse
-		err = json.Unmarshal(body, &msg)
-		if err != nil {
-			return nil, err
+		var msg EdgegapApiMessage
+		if jsonErr := json.Unmarshal(body, &msg); jsonErr != nil || msg.Message == "" {
+			return nil, fmt.Errorf("could not create deployment: status %d, body: %s", reply.StatusCode, string(body))
 		}
-		return &msg, errors.New("could not create deployment")
+		return nil, fmt.Errorf("could not create deployment: status %d: %s", reply.StatusCode, msg.Message)
 	}
 
 	// Parse the response body

--- a/pkg/fleetmanager/event_manager.go
+++ b/pkg/fleetmanager/event_manager.go
@@ -5,16 +5,19 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
-	"github.com/edgegap/nakama-edgegap/internal/helpers"
-	"github.com/heroiclabs/nakama-common/runtime"
 	"strings"
 	"time"
+
+	"github.com/edgegap/nakama-edgegap/internal/helpers"
+	"github.com/heroiclabs/nakama-common/runtime"
 )
 
 const (
-	RpcIdEventDeployment = "edgegap_deployment"
-	RpcIdEventConnection = "edgegap_connection"
-	RpcIdEventInstance   = "edgegap_instance"
+	RpcIdEventDeploymentReady      = "edgegap_deployment_ready"
+	RpcIdEventDeploymentError      = "edgegap_deployment_error"
+	RpcIdEventDeploymentTerminated = "edgegap_deployment_terminated"
+	RpcIdEventConnection           = "edgegap_connection"
+	RpcIdEventInstance             = "edgegap_instance"
 )
 
 var (
@@ -53,10 +56,7 @@ func (eem *EdgegapEventManager) unpack(ctx context.Context, payload string) (*Ev
 	}, nil
 }
 
-// handleDeploymentEvent processes deployment-related events.
-// It extracts the payload, updates the instance session status, and logs errors if necessary.
-func (eem *EdgegapEventManager) handleDeploymentEvent(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, payload string) (string, error) {
-	logger.Info("Handle Deployment")
+func (eem *EdgegapEventManager) handleDeploymentReadyEvent(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, payload string) (string, error) {
 	msg, err := eem.unpack(ctx, payload)
 	if err != nil {
 		return "", err
@@ -75,40 +75,72 @@ func (eem *EdgegapEventManager) handleDeploymentEvent(ctx context.Context, logge
 		return "", errors.New("no instance found with requestId " + deployment.RequestId)
 	}
 
-	badState := true
-
-	switch deployment.CurrentStatus {
-	case DeploymentStatusReady:
-		logger.Info("Edgegap deployment ready #%s", deployment.RequestId)
-		instance.Status = EdgegapStatusRunning
-		instance.ConnectionInfo = &runtime.ConnectionInfo{
-			IpAddress: deployment.PublicIp,
-			DnsName:   deployment.Fqdn,
-			Port:      deployment.Ports[eem.config.PortName].External,
-		}
-		badState = false
-	case DeploymentStatusError:
-		logger.Warn("Edgegap deployment error #%s : %s", deployment.RequestId, deployment.Error)
-		instance.Status = EdgegapStatusError
-	default:
-		logger.Error("Unknown deployment status %s", deployment.CurrentStatus)
-		instance.Status = EdgegapStatusUnknown
+	logger.Info("Edgegap deployment ready #%s", deployment.RequestId)
+	instance.Status = EdgegapStatusRunning
+	instance.ConnectionInfo = &runtime.ConnectionInfo{
+		IpAddress: deployment.PublicIp,
+		DnsName:   deployment.Fqdn,
+		Port:      deployment.Ports[eem.config.PortName].External,
 	}
 
-	if badState {
-		ei, err := eem.sm.ExtractEdgegapInstance(instance)
-		if err != nil {
-			return "", err
-		}
-		fmInstance.callbackHandler.InvokeCallback(ei.CallbackId, runtime.CreateError, nil, nil, nil, errors.New("an error occurred with edgegap deployment"))
-	}
+	return "ok", eem.sm.updateDbInstance(ctx, instance)
+}
 
-	err = eem.sm.updateDbInstance(ctx, instance)
+func (eem *EdgegapEventManager) handleDeploymentErrorEvent(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, payload string) (string, error) {
+	msg, err := eem.unpack(ctx, payload)
 	if err != nil {
 		return "", err
 	}
 
-	return "ok", nil
+	var deployment EdgegapDeploymentStatus
+	if err := json.Unmarshal([]byte(msg.payload), &deployment); err != nil {
+		return "", err
+	}
+
+	instance, err := eem.sm.getDbInstance(ctx, deployment.RequestId)
+	if err != nil {
+		return "", err
+	}
+	if instance == nil {
+		return "", errors.New("no instance found with requestId " + deployment.RequestId)
+	}
+
+	logger.Warn("Edgegap deployment error #%s : %s", deployment.RequestId, deployment.Error)
+	instance.Status = EdgegapStatusError
+
+	ei, err := eem.sm.ExtractEdgegapInstance(instance)
+	if err != nil {
+		logger.Error("failed to extract edgegap instance for error callback #%s: %v", deployment.RequestId, err)
+		return "", err
+	}
+	fmInstance.callbackHandler.InvokeCallback(ei.CallbackId, runtime.CreateError, nil, nil, nil, errors.New("an error occurred with edgegap deployment"))
+
+	return "ok", eem.sm.updateDbInstance(ctx, instance)
+}
+
+func (eem *EdgegapEventManager) handleDeploymentTerminatedEvent(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, payload string) (string, error) {
+	msg, err := eem.unpack(ctx, payload)
+	if err != nil {
+		return "", err
+	}
+
+	var deployment EdgegapDeploymentStatus
+	if err := json.Unmarshal([]byte(msg.payload), &deployment); err != nil {
+		return "", err
+	}
+
+	instance, err := eem.sm.getDbInstance(ctx, deployment.RequestId)
+	if err != nil {
+		return "", err
+	}
+	if instance == nil {
+		return "", errors.New("no instance found with requestId " + deployment.RequestId)
+	}
+
+	logger.Info("Edgegap deployment terminated #%s", deployment.RequestId)
+	instance.Status = EdgegapStatusTerminated
+
+	return "ok", eem.sm.updateDbInstance(ctx, instance)
 }
 
 // handleConnectionEvent processes connection-related events.

--- a/pkg/fleetmanager/event_manager.go
+++ b/pkg/fleetmanager/event_manager.go
@@ -56,6 +56,8 @@ func (eem *EdgegapEventManager) unpack(ctx context.Context, payload string) (*Ev
 	}, nil
 }
 
+// handleDeploymentReadyEvent processes the deployment "ready" webhook from Edgegap.
+// It marks the instance as running and stores the connection info (IP, FQDN, external port).
 func (eem *EdgegapEventManager) handleDeploymentReadyEvent(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, payload string) (string, error) {
 	msg, err := eem.unpack(ctx, payload)
 	if err != nil {
@@ -86,6 +88,9 @@ func (eem *EdgegapEventManager) handleDeploymentReadyEvent(ctx context.Context, 
 	return "ok", eem.sm.updateDbInstance(ctx, instance)
 }
 
+// handleDeploymentErrorEvent processes the deployment "error" webhook from Edgegap.
+// It marks the instance as errored and invokes the CreateError callback so the
+// caller that requested the deployment is notified of the failure.
 func (eem *EdgegapEventManager) handleDeploymentErrorEvent(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, payload string) (string, error) {
 	msg, err := eem.unpack(ctx, payload)
 	if err != nil {
@@ -105,7 +110,7 @@ func (eem *EdgegapEventManager) handleDeploymentErrorEvent(ctx context.Context, 
 		return "", errors.New("no instance found with requestId " + deployment.RequestId)
 	}
 
-	logger.Warn("Edgegap deployment error #%s : %s", deployment.RequestId, deployment.Error)
+	logger.Warn("Edgegap deployment error #%s : %s", deployment.RequestId, deployment.ErrorDetail)
 	instance.Status = EdgegapStatusError
 
 	ei, err := eem.sm.ExtractEdgegapInstance(instance)
@@ -118,6 +123,8 @@ func (eem *EdgegapEventManager) handleDeploymentErrorEvent(ctx context.Context, 
 	return "ok", eem.sm.updateDbInstance(ctx, instance)
 }
 
+// handleDeploymentTerminatedEvent processes the deployment "terminated" webhook from Edgegap.
+// It marks the instance as terminated so the sync worker can clean it from storage.
 func (eem *EdgegapEventManager) handleDeploymentTerminatedEvent(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, payload string) (string, error) {
 	msg, err := eem.unpack(ctx, payload)
 	if err != nil {

--- a/pkg/fleetmanager/fleet_manager.go
+++ b/pkg/fleetmanager/fleet_manager.go
@@ -113,7 +113,7 @@ func (efm *EdgegapFleetManager) Create(ctx context.Context, maxPlayers int, user
 
 	// Validate Edgegap response
 	if deployment.RequestId == "" {
-		efm.logger.WithField("error", deployment.Message).Error("Failed to create Edgegap instance: %s", deployment.Message)
+		efm.logger.Error("Failed to create Edgegap instance: empty request_id in response")
 		efm.callbackHandler.InvokeCallback(callbackId, runtime.CreateError, nil, nil, nil, errors.New("error while creating Edgegap Deployment"))
 		return errors.New("failed to create deployment")
 	}
@@ -244,7 +244,9 @@ func (efm *EdgegapFleetManager) syncInstancesWorker() {
 
 		activeInstancesMap := make(map[string]struct{}, len(deployments))
 		for _, i := range deployments {
-			activeInstancesMap[i.RequestId] = struct{}{}
+			if i.Status != DeploymentStatusError {
+				activeInstancesMap[i.RequestId] = struct{}{}
+			}
 		}
 
 		instancesToRemove := make([]string, 0)

--- a/pkg/fleetmanager/models.go
+++ b/pkg/fleetmanager/models.go
@@ -2,11 +2,6 @@ package fleetmanager
 
 import "time"
 
-const (
-	DeploymentStatusReady = "Status.READY"
-	DeploymentStatusError = "Status.ERROR"
-)
-
 type EdgegapInstanceInfo struct {
 	MaxPlayers            int       `json:"max_players"`
 	AvailableSeats        int       `json:"available_seats"`
@@ -17,8 +12,13 @@ type EdgegapInstanceInfo struct {
 	Connections           []string  `json:"connections"`
 }
 
-type EdgegapDeploymentUser struct {
+type EdgegapUserData struct {
 	IpAddress string `json:"ip_address"`
+}
+
+type EdgegapDeploymentUser struct {
+	UserType string          `json:"user_type"`
+	UserData EdgegapUserData `json:"user_data"`
 }
 
 type EdgegapEnvironmentVariable struct {
@@ -32,12 +32,14 @@ type EdgegapWebhook struct {
 }
 
 type EdgegapDeploymentCreation struct {
-	ApplicationName      string                       `json:"application_name"`
+	Application          string                       `json:"application"`
 	Version              string                       `json:"version"`
 	Users                []EdgegapDeploymentUser      `json:"users"`
 	EnvironmentVariables []EdgegapEnvironmentVariable `json:"environment_variables"`
 	Tags                 []string                     `json:"tags"`
-	Webhook              EdgegapWebhook               `json:"webhook"`
+	WebhookOnReady       EdgegapWebhook               `json:"webhook_on_ready"`
+	WebhookOnError       EdgegapWebhook               `json:"webhook_on_error"`
+	WebhookOnTerminated  EdgegapWebhook               `json:"webhook_on_terminated"`
 }
 
 type EdgegapDeploymentPort struct {
@@ -59,18 +61,20 @@ type EdgegapDeploymentStatus struct {
 	Ports         map[string]EdgegapDeploymentPort `json:"ports"`
 }
 
-type EdgegapBetaDeployment struct {
+type EdgegapDeploymentResponse struct {
 	RequestId string `json:"request_id"`
-	Message   string `json:"message"`
 }
 
 type EdgegapApiMessage struct {
 	Message string `json:"message"`
 }
 
+const DeploymentStatusError = "Status.ERROR"
+
 type EdgegapDeploymentSummary struct {
 	RequestId string `json:"request_id"`
 	Ready     bool   `json:"ready"`
+	Status    string `json:"status"`
 }
 
 type EdgegapPagination struct {

--- a/pkg/fleetmanager/storage.go
+++ b/pkg/fleetmanager/storage.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"github.com/heroiclabs/nakama-common/runtime"
 	"time"
+
+	"github.com/heroiclabs/nakama-common/runtime"
 )
 
 // ErrorNoVersionFound is returned when no Edgegap version is found in storage
@@ -15,18 +16,19 @@ var ErrorNoVersionFound = errors.New("no Edgegap version found in storage")
 const (
 	StorageEdgegapIndex               = "_edgegap_instances_idx"
 	StorageEdgegapInstancesCollection = "_edgegap_instances"
-	StorageCollectionEdgegapVersion  = "system"
-	StorageKeyEdgegapVersion         = "edgegap_version"
+	StorageCollectionEdgegapVersion   = "system"
+	StorageKeyEdgegapVersion          = "edgegap_version"
 )
 
 // Constants representing different statuses of an Edgegap instance
 const (
-	EdgegapStatusRequested = "REQUESTED"
-	EdgegapStatusRunning   = "RUNNING"
-	EdgegapStatusReady     = "READY"
-	EdgegapStatusStopping  = "STOPPING"
-	EdgegapStatusError     = "ERROR"
-	EdgegapStatusUnknown   = "UNKNOWN"
+	EdgegapStatusRequested  = "REQUESTED"
+	EdgegapStatusRunning    = "RUNNING"
+	EdgegapStatusReady      = "READY"
+	EdgegapStatusStopping   = "STOPPING"
+	EdgegapStatusError      = "ERROR"
+	EdgegapStatusUnknown    = "UNKNOWN"
+	EdgegapStatusTerminated = "TERMINATED"
 )
 
 // StorageManager handles interactions with Nakama's storage system
@@ -142,31 +144,31 @@ func (sm *StorageManager) ReadEdgegapVersion(ctx context.Context) (string, int64
 			Key:        StorageKeyEdgegapVersion,
 		},
 	})
-	
+
 	if err != nil {
 		return "", 0, err
 	}
-	
+
 	if len(objects) == 0 {
 		return "", 0, ErrorNoVersionFound
 	}
-	
+
 	// Parse stored version
 	var storedData map[string]interface{}
 	if err := json.Unmarshal([]byte(objects[0].Value), &storedData); err != nil {
 		return "", 0, err
 	}
-	
+
 	version, ok := storedData["version"].(string)
 	if !ok || version == "" {
 		return "", 0, errors.New("invalid Edgegap version format in storage")
 	}
-	
+
 	var updatedAt int64
 	if timestamp, ok := storedData["updated_at"].(float64); ok {
 		updatedAt = int64(timestamp)
 	}
-	
+
 	return version, updatedAt, nil
 }
 

--- a/vendor/github.com/heroiclabs/nakama-common/runtime/runtime.go
+++ b/vendor/github.com/heroiclabs/nakama-common/runtime/runtime.go
@@ -1078,11 +1078,12 @@ type NakamaModule interface {
 	AuthenticateTokenGenerate(userID, username string, exp int64, vars map[string]string) (string, int64, error)
 
 	AccountGetId(ctx context.Context, userID string) (*api.Account, error)
-	AccountsGetId(ctx context.Context, userIDs []string) ([]*api.Account, error)
+	AccountsGetId(ctx context.Context, userIDs, deviceIDs []string) ([]*api.Account, error)
 	AccountUpdateId(ctx context.Context, userID, username string, metadata map[string]interface{}, displayName, timezone, location, langTag, avatarUrl string) error
 
 	AccountDeleteId(ctx context.Context, userID string, recorded bool) error
 	AccountExportId(ctx context.Context, userID string) (string, error)
+	AccountImportId(ctx context.Context, data, userID string) (*api.Account, error)
 
 	UsersGetId(ctx context.Context, userIDs []string, facebookIDs []string) ([]*api.User, error)
 	UsersGetUsername(ctx context.Context, usernames []string) ([]*api.User, error)
@@ -1353,6 +1354,7 @@ Satori runtime integration definitions.
 */
 type Satori interface {
 	Authenticate(ctx context.Context, id string, defaultProperties, customProperties map[string]string, noSession bool, ipAddress ...string) (*Properties, error)
+	IdentityDelete(ctx context.Context, id string) error
 	PropertiesGet(ctx context.Context, id string) (*Properties, error)
 	PropertiesUpdate(ctx context.Context, id string, properties *PropertiesUpdate) error
 	EventsPublish(ctx context.Context, id string, events []*Event, ipAddress ...string) error

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,5 +1,5 @@
-# github.com/heroiclabs/nakama-common v1.44.2
-## explicit; go 1.25.5
+# github.com/heroiclabs/nakama-common v1.45.0
+## explicit; go 1.26.1
 github.com/heroiclabs/nakama-common/api
 github.com/heroiclabs/nakama-common/rtapi
 github.com/heroiclabs/nakama-common/runtime


### PR DESCRIPTION
- Switch POST endpoint from /beta/deployments to /v2/deployments
- Update request struct: application_name → application, single webhook → three separate webhooks (on_ready, on_error, on_terminated)
- Update user struct to v2 format: {user_type, user_data: {ip_address}}
- Replace single handleDeploymentEvent RPC with three focused handlers.  (ready/error/terminated), each registered on its own RPC endpoint
- Add EdgegapStatusTerminated constant for terminated deployments
- Fix syncInstancesWorker to exclude Status.ERROR deployments from the active map so errored instances are cleaned up from storage
- Rename EdgegapBetaDeployment → EdgegapDeploymentResponse